### PR TITLE
Modified __GNUC__ vsnprintf prototype declaration to exclude OSX

### DIFF
--- a/bstrlib.c
+++ b/bstrlib.c
@@ -2755,7 +2755,7 @@ struct genBstrList g;
 #define START_VSNBUFF (256)
 #else
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__APPLE__)
 /* Something is making gcc complain about this prototype not being here, so 
    I've just gone ahead and put it in. */
 extern int vsnprintf (char *buf, size_t count, const char *format, va_list arg);


### PR DESCRIPTION
`bstrlib` does not compile on OSX without this change. See,
- [Learn C the Hard Way](http://c.learncodethehardway.org/book/ex26.html), the source of this fix
- [liballium](https://github.com/Yawning/liballium/issues/3). They take the [declaration out entirely](https://github.com/Yawning/liballium/commit/0c9b50f5550caf591df505913a37a69626ddf5ff), saying it is no longer needed given more complete libc implementations
