### PR TITLE
Removed compiler warnings [-Wself-assign] for a cleaner build output …

### DIFF
--- a/bstraux.c
+++ b/bstraux.c
@@ -1,3 +1,4 @@
+
 /*
  * This source file is part of the bstring string library.  This code was
  * written by Paul Hsieh in 2002-2015, and is covered by the BSD open source
@@ -24,6 +25,10 @@
 #include <ctype.h>
 #include "bstrlib.h"
 #include "bstraux.h"
+
+#ifndef UNUSED
+#define UNUSED(x) (void)(x)
+#endif
 
 /*  bstring bTail (bstring b, int n)
  *
@@ -197,10 +202,10 @@ int i, l, c;
 }
 
 static size_t readNothing (void *buff, size_t elsize, size_t nelem, void *parm) {
-	buff = buff;
-	elsize = elsize;
-	nelem = nelem;
-	parm = parm;
+	UNUSED(buff);
+	UNUSED(elsize);
+	UNUSED(nelem);
+	UNUSED(parm);
 	return 0; /* Immediately indicate EOF. */
 }
 


### PR DESCRIPTION
I added an UNDEFINED(X) macro in the single file that produces [-Wself-assign] warnings at build time. 

This removes the false sense of something being wrong; the sentiment in the code is clear and perfectly legitimate. However, some build processes take output as a sign of weakness or failure!
